### PR TITLE
Load question type from CSV with proper validation

### DIFF
--- a/src/controller/admin.py
+++ b/src/controller/admin.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, Response
+from flask import abort, Blueprint, Response
 from flask_login import login_required
 import os
 
@@ -25,6 +25,9 @@ def reload():
         Question.drop_rows()
 
         # load new rows
-        question_rows = Question.insert(csv_file)
-        Application.insert(csv_file, question_rows)
-        return Response('Reloaded applications from CSV file', 200)
+        try:
+            question_rows = Question.insert(csv_file)
+            Application.insert(csv_file, question_rows)
+            return Response('Reloaded applications from CSV file', 200)
+        except ValueError as e:
+            abort(400, str(e))

--- a/src/models/Application.py
+++ b/src/models/Application.py
@@ -29,7 +29,8 @@ class Application(db.Model, ModelUtils, Serializer):
     @staticmethod
     def get_applications_from_csv(csv_file):
         """Get applications from CSV file"""
-        return list(csv.reader(csv_file))
+        applications = list(csv.reader(csv_file))
+        return applications[1:]
 
     @staticmethod
     def convert_applications_to_rows(applications):

--- a/src/models/Question.py
+++ b/src/models/Question.py
@@ -39,6 +39,26 @@ class Question(db.Model, ModelUtils, Serializer):
         ]
 
     @staticmethod
-    def convert_question_to_row(index, question):
+    def convert_question_to_row(index, question_with_type):
         """Convert question into row to insert into database"""
-        return Question(question=question, question_type=QuestionType.essay, index=index)
+        question_with_type_list = question_with_type.split('|')
+        if len(question_with_type_list) < 2:
+            raise ValueError(
+                'question or question type not provided for: {question_with_type}'.format(
+                    question_with_type=question_with_type))
+        elif len(question_with_type_list) > 2:
+            raise ValueError(
+                'only question and question type should be provided for: {question_with_type}'.
+                format(question_with_type=question_with_type))
+
+        raw_question, raw_question_type_string = question_with_type_list
+        question = raw_question.strip()
+        question_type_string = raw_question_type_string.strip()
+
+        try:
+            question_type = QuestionType[question_type_string]
+        except KeyError:
+            raise ValueError('question type not recognized for: {question_with_type}'.format(
+                question_with_type=question_with_type))
+
+        return Question(question=question, question_type=question_type, index=index)

--- a/src/models/enums/QuestionType.py
+++ b/src/models/enums/QuestionType.py
@@ -2,6 +2,13 @@ from enum import auto, Enum
 
 
 class QuestionType(Enum):
-    ignore = auto()
+    communicationsOptIn = auto()
+    demographic = auto()
+    dietaryRestriction = auto()
+    email = auto()
     essay = auto()
-    multiple_choice = auto()
+    ignore = auto()
+    link = auto()
+    resumeLink = auto()
+    resumeSharingOptIn = auto()
+    shirtSize = auto()


### PR DESCRIPTION
With this change, the question type of a question is loaded from the CSV. This means that the Typeform CSV cannot be directly imported into the app, but instead modified first to add the correct question types.

The second row of the CSV is now expected to hold the question type. Validation errors will be thrown if this question type doesn't match any known question types.

A sample CSV for testing has been uploaded to the team's Google Drive in the Technical directory under 2019.