### PR TITLE
Enforce max number of applications that a user can rate

### DIFF
--- a/src/controller/review.py
+++ b/src/controller/review.py
@@ -3,6 +3,7 @@ from flask_login import current_user, login_required
 
 from src.models.Answer import Answer
 from src.models.Application import Application
+from src.models.Settings import Settings
 from src.models.enums.Role import Role
 from src.models.lib.Serializer import Serializer
 from src.shared import Shared
@@ -38,6 +39,13 @@ def is_authorized(application_id, is_read_only):
 @login_required
 def get_application():
     """Get application for user"""
+    if current_user.role != Role.admin:
+        settings = Settings.get_settings()
+        application_count = Application.get_count_of_applications_for_user(current_user.id)
+        if application_count >= settings.application_limit:
+            # no more applications to score for user
+            return Response(status=204)
+
     application = Application.get_application_for_user(current_user.id)
     if application is None:
         # no more applications to score

--- a/src/models/Application.py
+++ b/src/models/Application.py
@@ -170,6 +170,13 @@ class Application(db.Model, ModelUtils, Serializer):
             .filter((Application.assigned_to == user_id) & ((Application.score != 0) | ((Application.score == 0) & (Application.last_modified > cutoff))))
 
     @staticmethod
+    def get_count_of_applications_for_user(user_id):
+        """Returns count of applications associated with user ID"""
+        cutoff = datetime.now() - timedelta(hours=1)
+        return db.session.query(func.count(Application.id)) \
+            .filter((Application.assigned_to == user_id) & ((Application.score != 0) | ((Application.score == 0) & (Application.last_modified > cutoff)))).scalar()
+
+    @staticmethod
     def get_all_applications():
         """Returns all applications"""
         return db.session.query(Application)


### PR DESCRIPTION
This limit only applies to normal users. An admin can change this threshold in the settings.