### PR TITLE
Fix 500 error if invalid application ID is given and check authorization properly

### DIFF
--- a/src/models/Application.py
+++ b/src/models/Application.py
@@ -152,15 +152,7 @@ class Application(db.Model, ModelUtils, Serializer):
     def get_application(application_id):
         """Returns an application, for admin or server-side"""
         return db.session.query(Application) \
-            .filter(Application.id == application_id).one()
-
-
-    @staticmethod
-    def get_application_id_by_user(application_id, user_id):
-        """Returns all an application associated with user ID"""
-        return db.session.query(Application) \
-            .filter((Application.assigned_to == user_id) & (Application.id == application_id)).one()
-
+            .filter(Application.id == application_id).first()
 
     @staticmethod
     def get_all_applications_for_user(user_id):


### PR DESCRIPTION
* Decided to use `get_application` for both normal users and admins - got rid of `get_application_id_by_user` as a result
* Changed from `.one()` to `first()` in the query since the former throws an exception if there is not exactly one result, resulting in a 500 error
* Fixed not throwing a 404 error if the user is an admin and the application doesn't exist
* `score_application` is not a read only operation and should not be treated as such when checking if a user is authorized for the action 